### PR TITLE
Implement ECFG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@ ID
 package-quickstart.el
 
 # Project configuration.
-.emacscfg
+.ecfg

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@ ID
 package-quickstart.el
 
 # Project configuration.
-.ecfg
+/.ecfg

--- a/defuns/emacscfg.el
+++ b/defuns/emacscfg.el
@@ -17,92 +17,93 @@
 
 (require 'cl-lib)
 
-(defconst ecfg-project-root-dir-use-truename t
+(defconst ecfg-use-truename t
   "Non-nil means always expand filenames using function `file-truename'.")
 
-(defconst ecfg-config-file ".ecfg.el"
-  "The configuration file name being used to configure current project.")
+(defconst ecfg-workspace-name ".ecfg"
+  "Workspace directory name being used to configure current project.")
 
-(defun ecfg--get-project-root ()
-  "Get the project root directory of the curent opened buffer."
+(defun ecfg--workspace-root ()
+  "Resolve workspace root path based on currently opened buffer."
   (let ((file-name (buffer-file-name))
-        (project-root (when (fboundp 'projectile-project-root)
-                        (projectile-project-root))))
-    (unless project-root
+        (workspace (when (fboundp 'projectile-project-root)
+                     (projectile-project-root))))
+    (unless workspace
       ;; Get the current working directory using `buffer-file-name'
       ;; or `default-directory'
       (if file-name
-          (setq project-root (file-name-directory file-name))
-        (setq project-root (expand-file-name default-directory)))
+          (setq workspace (file-name-directory file-name))
+        (setq workspace (expand-file-name default-directory)))
 
       ;; Expand real path of the obtained working directory (if enabled)
-      (when ecfg-project-root-dir-use-truename
-        (setq project-root (file-truename project-root)))
+      (when ecfg-use-truename
+        (setq workspace (file-truename workspace)))
 
-      ;; Scan for the real project root of the opened file.
-      ;; We're looking either for the `ecfg-config-file' file,
+      ;; Scan for the real workspace path of the opened file.
+      ;; We're looking either for the `ecfg-config-dir' directiry,
       ;; or the '.projectile' file, or the '.git' directory.
       (let (last-dir)
         (while
-            (not (or (file-exists-p (concat project-root ecfg-config-file))
-                     (file-exists-p (concat project-root ".projectile"))
-                     (file-directory-p (concat project-root ".git"))
-                     (string= project-root "/")))
-          (setq last-dir project-root
-                project-root (file-name-directory
-                              (directory-file-name project-root)))
-          (when (string= last-dir project-root)
-            (setq project-root "/")))))
+            (not (or (file-directory-p (concat workspace ecfg-workspace-name))
+                     (file-exists-p (concat workspace ".projectile"))
+                     (file-directory-p (concat workspace ".git"))
+                     (string= workspace "/")))
+          (setq last-dir workspace
+                workspace (file-name-directory
+                           (directory-file-name workspace)))
+          (when (string= last-dir workspace)
+            (setq workspace "/")))))
 
-    (when (or (string= project-root "/") (equal project-root ""))
-      (message "ECFG: Unable to resolve project root")
-      (setq project-root nil))
+    (when (or (string= workspace "/") (equal workspace ""))
+      (message "ECFG: Unable to resolve workspace root path")
+      (setq workspace nil))
 
-    ;; Return resolved project root
-    project-root))
+    ;; Return resolved workspace root path
+    workspace))
 
-(defun ecfg--init-project (project-root force)
-  "Init configuration located at PROJECT-ROOT taking into account FORCE flag."
-  )
+(defun ecfg--create-workspace (project-root force)
+  "Create a workspace located at PROJECT-ROOT taking into account FORCE flag."
+  (message "workspace: %S force: %S" project-root force))
 
-(defun ecfg-init ()
-  "Initialize ECFG configuration."
+(defun ecfg-init-workspace ()
+  "Initialize ECFG workspace.
+ECFG workspace is usually just your project root folder."
   (interactive)
-  (ecfg--init-project (ecfg--get-project-root) t))
+  (ecfg--create-workspace (ecfg--workspace-root) t))
 
-(defun ecfg--create-config ()
-  "Create an empty config."
-  (make-hash-table :test 'equal))
+;; (defun ecfg--create-config ()
+;;   "Create an empty config."
+;;   (make-hash-table :test 'equal))
 
-(defun ecfg--read-from-file (filename)
-  "Read data from FILENAME."
-  (let (data)
-    (with-temp-buffer
-      (insert-file-contents filename)
-      (cl-assert (eq (point) (point-min)))
-      (setq data (read (current-buffer)))
-      (unless (hash-table-p data)
-        (setq data (ecfg--create-config))))
-    data))
+;; (defun ecfg--read-from-file (filename)
+;;   "Read data from FILENAME."
+;;   (let (data)
+;;     (with-temp-buffer
+;;       (insert-file-contents filename)
+;;       (cl-assert (eq (point) (point-min)))
+;;       (setq data (read (current-buffer)))
+;;       (unless (hash-table-p data)
+;;         (setq data (ecfg--create-config))))
+;;     data))
 
-(defun ecfg--print-to-file (filename data)
-  "Write a DATA to the FILENAME."
-  (with-temp-file filename
-    (prin1 data (current-buffer))))
+;; (defun ecfg--print-to-file (filename data)
+;;   "Write a DATA to the FILENAME."
+;;   (with-temp-file filename
+;;     (prin1 data (current-buffer))))
 
-(defun ecfg-read-project-config ()
-  "Read the project configuration."
-  (let ((path (concat (projectile-project-root) ecfg-config-file)))
-    (if (file-exists-p path)
-        (ecfg--read-from-file path)
-      (ecfg--create-config))))
+;; (defun ecfg-read-project-config ()
+;;   "Read the project configuration."
+;;   (let ((path (concat (projectile-project-root) ecfg-config-file)))
+;;     (if (file-exists-p path)
+;;         (ecfg--read-from-file path)
+;;       (ecfg--create-config))))
 
-(defun ecfg-save-project-config (data)
-  "Save the project configuration to file.
-DATA should represent a valid hashtable object."
-  (let ((path (concat (projectile-project-root) ecfg-config-file)))
-    (when (hash-table-p data)
-      (ecfg--print-to-file path data))))
+;; (defun ecfg-save-project-config (data)
+;;   "Save the project configuration to file.
+;; DATA should represent a valid hashtable object."
+;;   (let ((path (concat (projectile-project-root) ecfg-config-file)))
+;;     (when (hash-table-p data)
+;;       (ecfg--print-to-file path data))))
 
 (provide 'emacscfg)
 ;;; emacscfg.el ends here

--- a/defuns/emacscfg.el
+++ b/defuns/emacscfg.el
@@ -20,9 +20,6 @@
 
 ;;;; Customization
 
-(defconst ecfg-use-truename t
-  "Non-nil means always expand filenames using function `file-truename'.")
-
 (defconst ecfg-workspace-name ".ecfg"
   "Workspace directory name being used to configure current project.")
 
@@ -97,8 +94,7 @@ Tries to resolve workspace root by lookup either for the
         (setq workspace (expand-file-name default-directory)))
 
       ;; Expand real path of the obtained working directory (if enabled)
-      (when ecfg-use-truename
-        (setq workspace (file-truename workspace)))
+      (setq workspace (file-truename workspace))
 
       ;; Scan for the real workspace path of the opened file.
       ;; We're looking either for the `ecfg-config-dir' directiry,

--- a/defuns/emacscfg.el
+++ b/defuns/emacscfg.el
@@ -197,6 +197,12 @@ If KEY is not found, return DFLT which default to nil."
         (plist-get data key)
       dflt)))
 
+(defun ecfg-set (key value)
+  "Associate KEY with VALUE in project configuration."
+  (let ((data (ecfg-load-config)))
+    (plist-put data key value)
+    (push (list (ecfg--workspace-root) data) ecfg-config-cache)))
+
 ;; (defun ecfg-save-project-config (data)
 ;;   "Save the project configuration to file.
 ;; DATA should represent a valid hashtable object."

--- a/defuns/emacscfg.el
+++ b/defuns/emacscfg.el
@@ -39,6 +39,13 @@
         :cc (list :include-path nil))
   "ECFG configuration template.")
 
+(defconst ecfg-footer-template
+  (concat "\n"
+          ";; Local Variables:\n"
+          ";; flycheck-disabled-checkers: (emacs-lisp-checkdoc)\n"
+          ";; End:\n")
+  "ECFG footer template.")
+
 ;;;; Utils
 
 (defun ecfg-read-from-file (filename)
@@ -68,7 +75,7 @@
       (let ((print-length nil)
             (print-level nil))
         (pp data (current-buffer)))
-      (insert (format "\n\n;; Local Variables:\n;; End:\n"))
+      (insert ecfg-footer-template)
       (condition-case nil
           (write-region (point-min) (point-max) path)
         (file-error (message "ECFG: can't write file %s" path)))

--- a/defuns/emacscfg.el
+++ b/defuns/emacscfg.el
@@ -16,10 +16,59 @@
 ;;; Code:
 
 (require 'cl-lib)
-(require 'projectile)
 
-(defconst ecfg-config-file ".emacscfg"
+(defconst ecfg-project-root-dir-use-truename t
+  "Non-nil means always expand filenames using function `file-truename'.")
+
+(defconst ecfg-config-file ".ecfg.el"
   "The configuration file name being used to configure current project.")
+
+(defun ecfg--get-project-root ()
+  "Get the project root directory of the curent opened buffer."
+  (let ((file-name (buffer-file-name))
+        (project-root (when (fboundp 'projectile-project-root)
+                        (projectile-project-root))))
+    (unless project-root
+      ;; Get the current working directory using `buffer-file-name'
+      ;; or `default-directory'
+      (if file-name
+          (setq project-root (file-name-directory file-name))
+        (setq project-root (expand-file-name default-directory)))
+
+      ;; Expand real path of the obtained working directory (if enabled)
+      (when ecfg-project-root-dir-use-truename
+        (setq project-root (file-truename project-root)))
+
+      ;; Scan for the real project root of the opened file.
+      ;; We're looking either for the `ecfg-config-file' file,
+      ;; or the '.projectile' file, or the '.git' directory.
+      (let (last-dir)
+        (while
+            (not (or (file-exists-p (concat project-root ecfg-config-file))
+                     (file-exists-p (concat project-root ".projectile"))
+                     (file-directory-p (concat project-root ".git"))
+                     (string= project-root "/")))
+          (setq last-dir project-root
+                project-root (file-name-directory
+                              (directory-file-name project-root)))
+          (when (string= last-dir project-root)
+            (setq project-root "/")))))
+
+    (when (or (string= project-root "/") (equal project-root ""))
+      (message "ECFG: Unable to resolve project root")
+      (setq project-root nil))
+
+    ;; Return resolved project root
+    project-root))
+
+(defun ecfg--init-project (project-root force)
+  "Init configuration located at PROJECT-ROOT taking into account FORCE flag."
+  )
+
+(defun ecfg-init ()
+  "Initialize ECFG configuration."
+  (interactive)
+  (ecfg--init-project (ecfg--get-project-root) t))
 
 (defun ecfg--create-config ()
   "Create an empty config."

--- a/site-lisp/ecfg.el
+++ b/site-lisp/ecfg.el
@@ -77,7 +77,7 @@
         (file-error (message "ECFG: can't write file %s" path)))
       (kill-buffer (current-buffer)))))
 
-(defun ecfg--workspace-root ()
+(defun ecfg-workspace-root ()
   "Resolve workspace root path based on currently opened buffer.
 
 Tries to resolve workspace root by lookup either for the
@@ -118,7 +118,7 @@ Tries to resolve workspace root by lookup either for the
     ;; Return resolved workspace root path
     workspace))
 
-(defun ecfg--storage-path (project-root)
+(defun ecfg-storage-path (project-root)
   "Return absolute path to directory where ECFG configuration should be located.
 
 Uses PROJECT-ROOT as a path to the directory, where ECFG configuration should be
@@ -132,13 +132,13 @@ located.  If this directory does not exist, tries to create it."
       (mkdir workspace-dir t))
     workspace-dir))
 
-(defun ecfg--config-path (project-root)
+(defun ecfg-config-path (project-root)
   "Return absolute path to workspace confguration.
 Uses PROJECT-ROOT as a project root."
   (let (workspace-dir config-path)
     (cl-assert (not (null project-root))
                t "project root is unknown")
-    (setq workspace-dir (ecfg--storage-path project-root)
+    (setq workspace-dir (ecfg-storage-path project-root)
           config-path (expand-file-name ecfg-config-name workspace-dir))
     config-path))
 
@@ -147,7 +147,7 @@ Uses PROJECT-ROOT as a project root."
   (let (config-file)
     (if project-root
         (progn
-          (setq config-file (ecfg--config-path project-root))
+          (setq config-file (ecfg-config-path project-root))
           ;; Check for file existence and its size
           (when (or (not (file-exists-p config-file))
                     (< (file-attribute-size (file-attributes config-file)) 4)
@@ -160,10 +160,10 @@ Uses PROJECT-ROOT as a project root."
 (defun ecfg-load-config (&optional project-root)
   "Return workspace configuration.
 
-Tries to use in memory cache if possible.  Optinal PROJECT-ROOT argument can be
+Tries to use in memory cache if possible.  Optional PROJECT-ROOT argument can be
 passed to point desired project root working to."
-  (let* ((project-root (or project-root (ecfg--workspace-root)))
-         (config-file (ecfg--config-path project-root))
+  (let* ((project-root (or project-root (ecfg-workspace-root)))
+         (config-file (ecfg-config-path project-root))
          (config-data (nth 1 (assoc-string project-root ecfg-config-cache))))
     (message "ecfg-config-cache after: %S" ecfg-config-cache)
     (message "config-data after: %S" config-data)
@@ -180,16 +180,14 @@ passed to point desired project root working to."
 
 (defun ecfg-init-workspace ()
   "Initialize ECFG workspace.
-
-ECFG workspace is usually just your project root folder.  Using
-\\[universal-argument] will force to re-initialize the the current workspace
-even if it already known."
+Using \\[universal-argument] will force to re-initialize the the current
+workspace even if it already known."
   (interactive)
-  (ecfg-create-workspace (ecfg--workspace-root)
+  (ecfg-create-workspace (ecfg-workspace-root)
                          (not (null current-prefix-arg))))
 
 (defun ecfg-get (key &optional dflt)
-  "Look up KEY in project configuration and return its assotiated value.
+  "Look up KEY in project configuration and return its associated value.
 If KEY is not found, return DFLT which default to nil."
   (let ((data (ecfg-load-config)))
     (if (plist-member data key)
@@ -197,9 +195,9 @@ If KEY is not found, return DFLT which default to nil."
       dflt)))
 
 (defun ecfg-set (key value)
-  "Associate KEY with VALUE in project configuration."
+  "Associate KEY with VALUE in a project configuration."
   (let ((data (ecfg-load-config))
-        (project-root (ecfg--workspace-root)))
+        (project-root (ecfg-workspace-root)))
     (plist-put data key value)
     (setq ecfg-config-cache (assoc-delete-all project-root ecfg-config-cache))
     (push (list project-root data) ecfg-config-cache)))

--- a/site-lisp/ecfg.el
+++ b/site-lisp/ecfg.el
@@ -38,7 +38,7 @@
 (defconst ecfg-footer-template
   (concat "\n"
           ";; Local Variables:\n"
-          ";; flycheck-disabled-checkers: (emacs-lisp-checkdoc)\n"
+          ";; flycheck-disabled-checkers: (emacs-lisp-checkdoc emacs-lisp)\n"
           ";; End:\n")
   "ECFG footer template.")
 

--- a/site-lisp/ecfg.el
+++ b/site-lisp/ecfg.el
@@ -179,10 +179,8 @@ workspace even if it already known."
   "Look up KEY in project configuration and return its associated value.
 If KEY is not found, return DFLT which default to nil."
   (let ((data (ecfg-load-config)) retval)
-    (setq retval dflt)
-    (when (plist-member data key)
-      (setq retval (plist-get data key))
-      (unless retval (setq retval dflt)))))
+    (setq retval (plist-get data key))
+    (if retval retval dflt)))
 
 (defun ecfg-set (key value)
   "Associate KEY with VALUE in a project configuration."

--- a/site-lisp/ecfg.el
+++ b/site-lisp/ecfg.el
@@ -1,4 +1,4 @@
-;;; emacscfg.el --- Simple way to configure Emacs projects. -*- lexical-binding: t; -*-
+;;; ecfg.el --- Simple way to configure Emacs projects. -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2019-2020 Serghei Iakovlev <egrep@protonmail.ch>
 
@@ -204,5 +204,5 @@ If KEY is not found, return DFLT which default to nil."
     (setq ecfg-config-cache (assoc-delete-all project-root ecfg-config-cache))
     (push (list project-root data) ecfg-config-cache)))
 
-(provide 'emacscfg)
-;;; emacscfg.el ends here
+(provide 'ecfg)
+;;; ecfg.el ends here

--- a/site-lisp/ecfg.el
+++ b/site-lisp/ecfg.el
@@ -178,10 +178,11 @@ workspace even if it already known."
 (defun ecfg-get (key &optional dflt)
   "Look up KEY in project configuration and return its associated value.
 If KEY is not found, return DFLT which default to nil."
-  (let ((data (ecfg-load-config)))
-    (if (plist-member data key)
-        (plist-get data key)
-      dflt)))
+  (let ((data (ecfg-load-config)) retval)
+    (setq retval dflt)
+    (when (plist-member data key)
+      (setq retval (plist-get data key))
+      (unless retval (setq retval dflt)))))
 
 (defun ecfg-set (key value)
   "Associate KEY with VALUE in a project configuration."

--- a/site-lisp/ecfg.el
+++ b/site-lisp/ecfg.el
@@ -191,5 +191,12 @@ If KEY is not found, return DFLT which default to nil."
     (setq ecfg-config-cache (assoc-delete-all project-root ecfg-config-cache))
     (push (list project-root data) ecfg-config-cache)))
 
+(defun ecfg-unset (key)
+  "Remove the association for KEY from a projectconfiguration, if there is one."
+  (let ((data (ecfg-load-config))
+        (project-root (ecfg-workspace-root)))
+    (setq ecfg-config-cache (assoc-delete-all project-root ecfg-config-cache))
+    (push (list project-root (map-delete data key)) ecfg-config-cache)))
+
 (provide 'ecfg)
 ;;; ecfg.el ends here

--- a/site-lisp/ecfg.el
+++ b/site-lisp/ecfg.el
@@ -192,11 +192,8 @@ If KEY is not found, return DFLT which default to nil."
     (push (list project-root data) ecfg-config-cache)))
 
 (defun ecfg-unset (key)
-  "Remove the association for KEY from a projectconfiguration, if there is one."
-  (let ((data (ecfg-load-config))
-        (project-root (ecfg-workspace-root)))
-    (setq ecfg-config-cache (assoc-delete-all project-root ecfg-config-cache))
-    (push (list project-root (map-delete data key)) ecfg-config-cache)))
+  "Remove the association for KEY from a project configuration, if there is one."
+  (ecfg-set key nil))
 
 (provide 'ecfg)
 ;;; ecfg.el ends here

--- a/site-lisp/ecfg.el
+++ b/site-lisp/ecfg.el
@@ -47,7 +47,6 @@
 (defun ecfg-read-from-file (filename)
   "Read a project configuration from FILENAME file."
   (let (data)
-    (message "Open special buffer")
     (if (file-readable-p filename)
         (with-current-buffer (get-buffer-create " *ECFG Project Configuration*")
           (delete-region (point-min) (point-max))
@@ -56,7 +55,6 @@
           (setq data (with-demoted-errors "Error reading ECFG file: %S"
                        (car (read-from-string
                              (buffer-substring (point-min) (point-max))))))
-          (message "Kill special buffer")
           (kill-buffer (current-buffer)))
       (setq data ecfg-config-template))
     data))
@@ -123,7 +121,6 @@ Tries to resolve workspace root by lookup either for the
 
 Uses PROJECT-ROOT as a path to the directory, where ECFG configuration should be
 located.  If this directory does not exist, tries to create it."
-  (message "Lookup for the storage directory...")
   (let (workspace-dir)
     (cl-assert (not (null project-root))
                t "project root is unknown")
@@ -152,7 +149,6 @@ Uses PROJECT-ROOT as a project root."
           (when (or (not (file-exists-p config-file))
                     (< (file-attribute-size (file-attributes config-file)) 4)
                     force)
-            (message "Config file either empty or absent. Creating...")
             (ecfg-write-data ecfg-config-template config-file)))
       (message
        "Unable to create workspace configuration: project root is unknown"))))
@@ -165,17 +161,10 @@ passed to point desired project root working to."
   (let* ((project-root (or project-root (ecfg-workspace-root)))
          (config-file (ecfg-config-path project-root))
          (config-data (nth 1 (assoc-string project-root ecfg-config-cache))))
-    (message "ecfg-config-cache after: %S" ecfg-config-cache)
-    (message "config-data after: %S" config-data)
     (unless config-data
-      (message "Config data is empty. Populating ...")
-      (message "Search for config file: %s" config-file)
       (when (file-readable-p config-file)
-        (message "Config file found. Loading ...")
         (setq config-data (ecfg-read-from-file config-file))
         (push (list project-root config-data) ecfg-config-cache)))
-    (message "ecfg-config-cache before: %S" ecfg-config-cache)
-    (message "config before: %S" config-data)
     config-data))
 
 (defun ecfg-init-workspace ()

--- a/site-lisp/editor.el
+++ b/site-lisp/editor.el
@@ -46,11 +46,8 @@
   (prog-mode . 80-column-rule))
 
 ;; Right margin bar.
-(use-package display-fill-column-indicator-mode
-  :unless (version< emacs-version "27")
-  :ensure nil
-  :hook
-  (prog-mode . display-fill-column-indicator-mode))
+(unless (version< emacs-version "27")
+  (add-hook 'prog-mode-hook #'display-fill-column-indicator-mode))
 
 (use-package rainbow-delimiters)
 

--- a/site-lisp/setup-tags.el
+++ b/site-lisp/setup-tags.el
@@ -17,7 +17,7 @@
 
 (require 'cl-macs)
 (require 'utils)
-(require 'emacscfg)
+(require 'ecfg)
 (require 'directories)
 
 ;;;; Constants

--- a/site-lisp/setup-tags.el
+++ b/site-lisp/setup-tags.el
@@ -210,7 +210,6 @@
 
 (defun setup-tags-fronted ()
   "Enable tags fronted using project configuration."
-  (message "type-of :tags-frontend: %S" (type-of (ecfg-get :tags-frontend)))
   (pcase (ecfg-get :tags-frontend)
     ;; string
     ("ggtags"    (tags-enable-ggtags))
@@ -221,7 +220,7 @@
     ;; nil
     ((pred null) nil)
     ;; unknown
-    (f           (error "Unknown tags fronted type: %S (%s)" f f))))
+    (f           (error "Unknown tags fronted type: %S" f))))
 
 (defsubst tags--apply-to-project-buffers (buffer project-root)
   "Apply tags configuration to project's BUFFER.

--- a/site-lisp/setup-tags.el
+++ b/site-lisp/setup-tags.el
@@ -220,10 +220,10 @@
     ;; nil
     ((pred null) nil)
     ;; unknown
-    (f           (error "Unknown tags fronted type: %S" f))))
+    (f           (error "Unknown tags fronted type: %S (%s)" f (type-of f)))))
 
-(defsubst tags--apply-to-project-buffers (buffer project-root)
-  "Apply tags configuration to project's BUFFER.
+(defsubst tags--apply-to-buffer (buffer project-root)
+  "Apply tags configuration to buffer BUFFER.
 The PROJECT-ROOT variable should point to the current project root."
   (with-current-buffer buffer
     (when (and (bufferp buffer)
@@ -234,15 +234,13 @@ The PROJECT-ROOT variable should point to the current project root."
 (defun tags-enable-project-wide (frontend)
   "Setup project wide FRONTEND to source code tagging system."
   (interactive
-   (list (completing-read
-          "Tags frontend: " '("ggtags" "rtags" "disable"))))
-  (let ((cfg (ecfg-read-project-config))
-        (tags-frontend (if (equal frontend "disable") nil (make-symbol frontend)))
-        (project-root (projectile-project-root)))
-    (puthash "tags-frontend" tags-frontend cfg)
-    (ecfg-save-project-config cfg)
+   (list (completing-read "Tags frontend: " '(ggtags rtags disable))))
+  (let ((project-root (projectile-project-root)))
+    (when (string= frontend "disable")
+      (setq frontend nil))
+    (ecfg-set :tags-frontend frontend)
     (cl-dolist (buffer (buffer-list))
-      (funcall #'tags--apply-to-project-buffers buffer project-root))))
+      (funcall #'tags--apply-to-buffer buffer project-root))))
 
 (provide 'setup-tags)
 

--- a/site-lisp/setup-tags.el
+++ b/site-lisp/setup-tags.el
@@ -209,19 +209,19 @@
               #'ggtags-eldoc-function))
 
 (defun setup-tags-fronted ()
-  "Common hook to enable tags fronted."
-  (let ((cfg (ecfg-read-project-config)))
-    (pcase (gethash "tags-frontend" cfg nil)
-      ;; string
-      ("ggtags"    (tags-enable-ggtags))
-      ("rtags"     (tags-enable-rtags))
-      ;; symbol
-      ('ggtags     (tags-enable-ggtags))
-      ('rtags      (tags-enable-rtags))
-      ;; nil
-      ((pred null) nil)
-      ;; unknown
-      (f           (error "Unknown tags fronted type: %S" f)))))
+  "Enable tags fronted using project configuration."
+  (message "type-of :tags-frontend: %S" (type-of (ecfg-get :tags-frontend)))
+  (pcase (ecfg-get :tags-frontend)
+    ;; string
+    ("ggtags"    (tags-enable-ggtags))
+    ("rtags"     (tags-enable-rtags))
+    ;; symbol
+    ('ggtags     (tags-enable-ggtags))
+    ('rtags      (tags-enable-rtags))
+    ;; nil
+    ((pred null) nil)
+    ;; unknown
+    (f           (error "Unknown tags fronted type: %S (%s)" f f))))
 
 (defsubst tags--apply-to-project-buffers (buffer project-root)
   "Apply tags configuration to project's BUFFER.


### PR DESCRIPTION
---
Initialize ECFG workspace. Using <kbd>C-u</kbd> will force to re-initialize the the current workspace even if it already known.
```elsip
(ecfg-init-workspace)
```

---
Return workspace configuration. Tries to use in memory cache if possible.  Optional `PROJECT-ROOT` argument can be passed to point desired project root working to.

```elisp
(ecfg-load-config "/home/user/projects/acme/")
```

---
Create a workspace located at `PROJECT-ROOT` taking into account `FORCE` flag.
```elisp
(ecfg-create-workspace "/home/user/projects/acme/" t)
```

---
Associate `KEY` with `VALUE` in a project configuration.
```elisp
(ecfg-set :tags-frontend 'gtags)
```

---
Look up `KEY` in project configuration and return its associated value. If KEY is not found, return `DFLT` which default to `nil`
```elisp
(ecfg-get :tags-frontend 'rtags)
```

---
Remove the association for KEY from a project configuration, if there is one
```elisp
(ecfg-unset :tags-frontend)
 ```

---
Current config file structure:
```elisp
(:version "1.0.0"
 :tags-frontend nil
 :cc (:include-path nil))
```